### PR TITLE
fix: nestjs yarn scripts and readme

### DIFF
--- a/nestjs/README.md
+++ b/nestjs/README.md
@@ -18,7 +18,7 @@ yarn install
 3. Create database
 
 ```
-yarn ts-node-esm create_db.ts
+yarn ts-node-esm create-db.ts
 ```
 
 4. Run migration
@@ -36,6 +36,6 @@ yarn migrate_and_start
 More cmds:
 ```
 yarn db:migrate:generate ./src/migrations/AddNewColumnToTables
-yarn ts-node-esm drop_db.ts
+yarn ts-node-esm drop-db.ts
 yarn test
 ```

--- a/nestjs/package.json
+++ b/nestjs/package.json
@@ -27,18 +27,18 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "ts-node": "ts-node -r tsconfig-paths/register -r dotenv/config",
     "ts-node-esm": "ts-node-esm -r dotenv/config -r tsconfig-paths/register",
-    "typeorm": "ts-node-esm -r tsconfig-paths/register ./node_modules/.bin/typeorm -d ./src/config/typeorm.config.ts",
+    "typeorm": "ts-node-esm -r tsconfig-paths/register ./node_modules/.bin/typeorm",
     "execute-tsnode": "yarn run ts-node-esm src/execute-script",
     "execute": "node dist/src/execute-script.js",
     "db:create": "node dist/create-db.js",
     "db:create:test": "NODE_ENV=test node dist/create-db.js",
     "db:schema:drop": "yarn typeorm schema:drop",
-    "db:migrate:generate": "yarn typeorm migration:generate",
-    "db:migrate:up": "yarn typeorm migration:run",
+    "db:migrate:generate": "yarn typeorm -d ./src/config/typeorm.config.ts migration:generate",
+    "db:migrate:up": "yarn typeorm -d ./src/config/typeorm.config.ts migration:run",
     "db:migrate:up:prod": "yarn typeorm -d dist/src/config/typeorm.config.js migration:run",
     "migrate_and_start": "yarn run ts-node-esm create_db.ts; yarn db:migrate:up; yarn start",
     "migrate_and_start_prod": "node dist/create-db.js; yarn db:migrate:up; yarn start:prod",
-    "db:migrate:down": "yarn typeorm migration:revert"
+    "db:migrate:down": "yarn typeorm -d ./src/config/typeorm.config.ts migration:revert"
   },
   "dependencies": {
     "@golevelup/nestjs-rabbitmq": "^3.4.0",

--- a/nestjs/package.json
+++ b/nestjs/package.json
@@ -35,10 +35,10 @@
     "db:schema:drop": "yarn typeorm schema:drop",
     "db:migrate:generate": "yarn typeorm -d ./src/config/typeorm.config.ts migration:generate",
     "db:migrate:up": "yarn typeorm -d ./src/config/typeorm.config.ts migration:run",
+    "db:migrate:down": "yarn typeorm -d ./src/config/typeorm.config.ts migration:revert",
     "db:migrate:up:prod": "yarn typeorm -d dist/src/config/typeorm.config.js migration:run",
     "migrate_and_start": "yarn run ts-node-esm create_db.ts; yarn db:migrate:up; yarn start",
-    "migrate_and_start_prod": "node dist/create-db.js; yarn db:migrate:up; yarn start:prod",
-    "db:migrate:down": "yarn typeorm -d ./src/config/typeorm.config.ts migration:revert"
+    "migrate_and_start_prod": "node dist/create-db.js; yarn db:migrate:up; yarn start:prod"
   },
   "dependencies": {
     "@golevelup/nestjs-rabbitmq": "^3.4.0",


### PR DESCRIPTION
### Description

This PR include:

- Fix commands which duplicate typeorm config

```json
"typeorm": "ts-node-esm -r tsconfig-paths/register ./node_modules/.bin/typeorm -d ./src/config/typeorm.config.ts",
"db:migrate:up:prod": "yarn typeorm -d dist/src/config/typeorm.config.js migration:run",
```

[Ref](https://github.com/wakumo/deBingo-api-v2/commit/7696ad39975d483af2b22f08cf4f71193b44024e)

- Create db script:
![image](https://github.com/user-attachments/assets/106e8f2c-4dde-49af-a6bc-838ab8af7b71)

- Generate migrations:
![image](https://github.com/user-attachments/assets/95aafced-83b8-4425-b6ed-600634b7d968)

- Migrate up prod:
![image](https://github.com/user-attachments/assets/94dddb05-1ce2-4f33-b950-6ccffdb1c18f)

- Migrate down:
![image](https://github.com/user-attachments/assets/35547338-1dd1-4377-9683-d877f1577086)

- Migrate up:
![image](https://github.com/user-attachments/assets/21fec6fa-7118-4d73-95c1-2d01fc7f8de0)
